### PR TITLE
Use "version-os-platform" tags over repo digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,17 @@ sudo dpkg -i libiothsm-std-1.0.2-aarch64.deb
 sudo dpkg -i iotedge_1.0.2-1_aarch64.deb
 ```
 
-Also, since IoT Edge has not published images for this exact architecture, the default configurations will fail. The daemon must be configured to pull in the arm32 image, which can be achieved with this change in the configuration file:
+Also, since IoT Edge has not published images for this exact architecture, the default configurations will fail. The daemon must be configured to pull in the arm32 image for all system modules, which can be achieved with this change in the configuration file:
 
 ```
 diff /etc/iotedge/config.yaml.orig /etc/iotedge/config.yaml
 74c74
 <     image: "mcr.microsoft.com/azureiotedge-agent:1.0"
 ---
->     image: "mcr.microsoft.com/azureiotedge-agent:1.0@sha256:14b82d77818dfaece1b8266335ff1c23fde3e7fc9937c334b5ad322af4744ed3"
+>     image: "mcr.microsoft.com/azureiotedge-agent:1.0.0-linux-arm32v7"
+<     image: "mcr.microsoft.com/azureiotedge-hub:1.0"
+---
+>     image: "mcr.microsoft.com/azureiotedge-hub:1.0.0-linux-arm32v7"
 ```
 
 The IoT Edge Hub image is chosen during deployment and one can see an example at [./jetson-tx2/deployment.json](./jetson-tx2/deployment.json).

--- a/jetson-tx2/deployment.json
+++ b/jetson-tx2/deployment.json
@@ -15,14 +15,14 @@
                   "edgeAgent": {
                       "type": "docker",
                       "settings": {
-                          "image": "mcr.microsoft.com/azureiotedge-agent:1.0@sha256:14b82d77818dfaece1b8266335ff1c23fde3e7fc9937c334b5ad322af4744ed3",
+                          "image": "mcr.microsoft.com/azureiotedge-agent:1.0.0-linux-arm32v7",
                           "createOptions": ""
                       }
                   },
                   "edgeHub": {
                       "type": "docker",
                       "settings": {
-                          "image": "mcr.microsoft.com/azureiotedge-hub:1.0@sha256:6a817122d7aa6e5772de3a7d638962c182537d24d25678d23d9816691c58f01d",
+                          "image": "mcr.microsoft.com/azureiotedge-hub:1.0.0-linux-arm32v7",
                           "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]}}}"
                       },
                       "status": "running",


### PR DESCRIPTION
Updates tags to use "version-os-platform" scheme instead of sha256 repo digest.  This will make it very clear that we are working with arm32v7 system modules in deployment.template.json on the nvidia-jetson and other aarch64 devices.